### PR TITLE
feat(config): add configuration for environment variables using dotenv

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,10 @@ dependencies {
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
+    testImplementation("org.mockito:mockito-core:4.0.0")
+    testImplementation("org.mockito:mockito-inline:4.0.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
 }
 
 tasks.test {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,16 +1,9 @@
 package no.uyqn
 
-import no.uyqn.git.GitFacade
-import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder
-import java.io.File
+import io.github.cdimascio.dotenv.dotenv
+import no.uyqn.config.Configuration
 
-fun main(args: Array<String>) {
-    val repository =
-        FileRepositoryBuilder()
-            .findGitDir(File(args[0]))
-            .build()
-    val git = GitFacade(Git(repository))
-
-    println(git.getDiff())
+fun main() {
+    val config = Configuration(dotenv = dotenv { directory = System.getProperty("user.dir") })
+    println(config.getEnvironmentVariable(Configuration.OPENAI_API_KEY))
 }

--- a/src/main/kotlin/config/Configuration.kt
+++ b/src/main/kotlin/config/Configuration.kt
@@ -1,0 +1,13 @@
+package no.uyqn.config
+
+import io.github.cdimascio.dotenv.Dotenv
+
+class Configuration(
+    private val dotenv: Dotenv,
+) {
+    fun getEnvironmentVariable(key: String): String = dotenv[key] ?: throw MissingEnvironmentalKeyException(key)
+
+    companion object {
+        const val OPENAI_API_KEY = "OPENAI_API_KEY"
+    }
+}

--- a/src/main/kotlin/config/MissingEnvironmentalKeyException.kt
+++ b/src/main/kotlin/config/MissingEnvironmentalKeyException.kt
@@ -1,0 +1,7 @@
+package no.uyqn.config
+
+class MissingEnvironmentalKeyException(
+    private val key: String,
+) : Exception(key) {
+    override fun toString(): String = "Missing environmental key $key"
+}

--- a/src/test/kotlin/config/ConfigurationTest.kt
+++ b/src/test/kotlin/config/ConfigurationTest.kt
@@ -1,0 +1,48 @@
+package config
+
+import io.github.cdimascio.dotenv.Dotenv
+import no.uyqn.config.Configuration
+import no.uyqn.config.MissingEnvironmentalKeyException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+class ConfigurationTest {
+    private lateinit var dotenv: Dotenv
+    private lateinit var configuration: Configuration
+
+    @BeforeEach
+    fun setUp() {
+        dotenv = Mockito.mock(Dotenv::class.java)
+        configuration = Configuration(dotenv)
+    }
+
+    @Test
+    fun `should return environment variable when key is present`() {
+        val key = Configuration.OPENAI_API_KEY
+        val expectedValue = "my-secret-api-key"
+
+        Mockito.`when`(dotenv[key]).thenReturn(expectedValue)
+
+        val result = configuration.getEnvironmentVariable(key)
+
+        assertEquals(expectedValue, result)
+    }
+
+    @Test
+    fun `should throw MissingEnvironmentalKeyException when key is missing`() {
+        val key = Configuration.OPENAI_API_KEY
+
+        Mockito.`when`(dotenv[key]).thenReturn(null)
+
+        val exception =
+            assertThrows(MissingEnvironmentalKeyException::class.java) {
+                configuration.getEnvironmentVariable(key)
+            }
+
+        assertTrue(exception.toString().contains(key))
+    }
+}


### PR DESCRIPTION
- Introduced `Configuration` class to manage environment variables via `dotenv`.
- Added custom exception `MissingEnvironmentalKeyException` for missing keys.
- Updated `Main.kt` to use `Configuration` for retrieving the `OPENAI_API_KEY`.
- Added unit tests for `Configuration` class using Mockito to mock dotenv behavior.
- Updated build dependencies in `build.gradle.kts` to include JUnit and Mockito for testing.


### Linked Issue(s)
- Closes #5 